### PR TITLE
[WIP] PoC: Offline editing

### DIFF
--- a/lib/load.php
+++ b/lib/load.php
@@ -64,3 +64,4 @@ require dirname( __FILE__ ) . '/widgets-page.php';
 require dirname( __FILE__ ) . '/experiments-page.php';
 require dirname( __FILE__ ) . '/customizer.php';
 require dirname( __FILE__ ) . '/edit-site-page.php';
+require dirname( __FILE__ ) . '/offline-editing.php';

--- a/lib/offline-editing.js
+++ b/lib/offline-editing.js
@@ -1,3 +1,4 @@
+/* @todo This file should be moved to a better location. */
 /* global wp, fetch, caches, ERROR_OFFLINE_URL, ERROR_MESSAGES, ERROR_500_URL */
 
 // IIFE is used for lexical scoping instead of just a braces block due to bug with const in Safari.

--- a/lib/offline-editing.js
+++ b/lib/offline-editing.js
@@ -1,0 +1,49 @@
+/* global wp, fetch, caches, ERROR_OFFLINE_URL, ERROR_MESSAGES, ERROR_500_URL */
+
+// IIFE is used for lexical scoping instead of just a braces block due to bug with const in Safari.
+( () => {
+	const queue = new wp.serviceWorker.backgroundSync.Queue( 'gutenbergPendingEdits' );
+	const errorMessages = {};
+
+	const editPostHandler = ( { url, event } ) => {
+		const clone = event.request.clone();
+		return fetch( event.request )
+			.then( ( response ) => {
+				return response;
+			} )
+			.catch( () => {
+				const bodyPromise = clone.blob();
+				bodyPromise.then(
+					function( body ) {
+						const request = event.request;
+						const req = new Request( request.url, {
+							method: request.method,
+							headers: request.headers,
+							mode: 'same-origin',
+							credentials: request.credentials,
+							referrer: request.referrer,
+							redirect: 'manual',
+							body,
+						} );
+
+						// Add request to queue.
+						queue.pushRequest( {
+							request: req,
+						} );
+					}
+				);
+
+				const init = {
+					status: null,
+				};
+
+				return new Response( JSON.stringify( { error: 'test' } ), init );
+			} );
+	};
+
+	wp.serviceWorker.routing.registerRoute(
+		/\/index\.php/,
+		editPostHandler,
+		'POST'
+	);
+} )();

--- a/lib/offline-editing.js
+++ b/lib/offline-editing.js
@@ -3,7 +3,6 @@
 // IIFE is used for lexical scoping instead of just a braces block due to bug with const in Safari.
 ( () => {
 	const queue = new wp.serviceWorker.backgroundSync.Queue( 'gutenbergPendingEdits' );
-	const errorMessages = {};
 
 	const editPostHandler = ( { url, event } ) => {
 		const clone = event.request.clone();
@@ -32,12 +31,6 @@
 						} );
 					}
 				);
-
-				const init = {
-					status: null,
-				};
-
-				return new Response( JSON.stringify( { error: 'test' } ), init );
 			} );
 	};
 

--- a/lib/offline-editing.php
+++ b/lib/offline-editing.php
@@ -1,0 +1,17 @@
+<?php
+
+if ( ! defined( 'ABSPATH' ) ) {
+	die( 'Silence is golden.' );
+}
+
+function gutenberg_register_offline_editing_service_worker_script( $scripts ) {
+	$scripts->register(
+		'gutenberg-offline-editing',
+		array(
+			'src'  => 'https://pwa.wordpress.test/wp-content/plugins/gutenberg/lib/offline-editing.js',
+			'deps' => array( 'wp-base-config' ),
+		)
+	);
+}
+
+add_action( 'wp_admin_service_worker', 'gutenberg_register_offline_editing_service_worker_script' );

--- a/lib/offline-editing.php
+++ b/lib/offline-editing.php
@@ -8,7 +8,7 @@ function gutenberg_register_offline_editing_service_worker_script( $scripts ) {
 	$scripts->register(
 		'gutenberg-offline-editing',
 		array(
-			'src'  => 'https://pwa.wordpress.test/wp-content/plugins/gutenberg/lib/offline-editing.js',
+			'src'  => plugin_dir_url( __FILE__ ) . 'offline-editing.js',
 			'deps' => array( 'wp-base-config' ),
 		)
 	);

--- a/packages/api-fetch/src/index.js
+++ b/packages/api-fetch/src/index.js
@@ -92,9 +92,9 @@ const defaultFetchHandler = ( nextOptions ) => {
 					.then( checkStatus )
 					.catch( ( response ) => parseAndThrowError( response, parse ) )
 					.then( ( response ) => parseResponseAndNormalizeError( response, parse ) ),
-			( test ) => {
-				debugger;
+			() => {
 				throw {
+					type: 'offline',
 					message: __( 'You do not have an internet connection, however, your changes will be synced once back online. Previewing and some editing is not available when offline.' ),
 				};
 			}

--- a/packages/api-fetch/src/index.js
+++ b/packages/api-fetch/src/index.js
@@ -92,10 +92,10 @@ const defaultFetchHandler = ( nextOptions ) => {
 					.then( checkStatus )
 					.catch( ( response ) => parseAndThrowError( response, parse ) )
 					.then( ( response ) => parseResponseAndNormalizeError( response, parse ) ),
-			() => {
+			( test ) => {
+				debugger;
 				throw {
-					code: 'fetch_error',
-					message: __( 'You are probably offline.' ),
+					message: __( 'You do not have an internet connection, however, your changes will be synced once back online. Previewing and some editing is not available when offline.' ),
 				};
 			}
 		);

--- a/packages/api-fetch/src/utils/response.js
+++ b/packages/api-fetch/src/utils/response.js
@@ -59,10 +59,6 @@ export function parseAndThrowError( response, shouldParseResponse = true ) {
 
 	return parseJsonAndNormalizeError( response )
 		.then( ( error ) => {
-			if ( 'test' === error.error ) {
-				debugger;
-				return response;
-			}
 			const unknownError = {
 				code: 'unknown_error',
 				message: __( 'An unknown error occurred.' ),

--- a/packages/api-fetch/src/utils/response.js
+++ b/packages/api-fetch/src/utils/response.js
@@ -59,6 +59,10 @@ export function parseAndThrowError( response, shouldParseResponse = true ) {
 
 	return parseJsonAndNormalizeError( response )
 		.then( ( error ) => {
+			if ( 'test' === error.error ) {
+				debugger;
+				return response;
+			}
 			const unknownError = {
 				code: 'unknown_error',
 				message: __( 'An unknown error occurred.' ),

--- a/packages/core-data/src/actions.js
+++ b/packages/core-data/src/actions.js
@@ -366,7 +366,7 @@ export function* saveEntityRecord(
 
 		// If we got to the point in the try block where we made an optimistic update,
 		// we need to roll it back here.
-		if ( persistedEntity && currentEdits ) {
+		if ( 'offline' !== error.type && persistedEntity && currentEdits ) {
 			yield receiveEntityRecords( kind, name, persistedEntity, undefined, true );
 			yield editEntityRecord(
 				kind,

--- a/packages/editor/src/store/actions.js
+++ b/packages/editor/src/store/actions.js
@@ -22,6 +22,7 @@ import {
 	getNotificationArgumentsForSaveSuccess,
 	getNotificationArgumentsForSaveFail,
 	getNotificationArgumentsForTrashFail,
+	getNotificationArgumentsForOfflineSync,
 } from './utils/notice-builder';
 import serializeBlocks from './utils/serialize-blocks';
 
@@ -261,7 +262,8 @@ export function* savePost( options = {} ) {
 		previousRecord.type,
 		previousRecord.id
 	);
-	if ( error ) {
+	debugger;
+	if ( error && error.message === 'test' ) {
 		const args = getNotificationArgumentsForSaveFail( {
 			post: previousRecord,
 			edits,
@@ -269,6 +271,18 @@ export function* savePost( options = {} ) {
 		} );
 		if ( args.length ) {
 			yield dispatch( 'core/notices', 'createErrorNotice', ...args );
+		}
+	} else if ( error ) {
+		const args = getNotificationArgumentsForOfflineSync( {
+			post: previousRecord,
+			edits,
+			error,
+		} );
+		if ( args.length ) {
+			yield dispatch( 'core/notices', 'createWarningNotice', ...args );
+		}
+		if ( ! options.isAutosave ) {
+			yield dispatch( 'core/block-editor', '__unstableMarkLastChangeAsPersistent' );
 		}
 	} else {
 		const updatedRecord = yield select( STORE_KEY, 'getCurrentPost' );

--- a/packages/editor/src/store/actions.js
+++ b/packages/editor/src/store/actions.js
@@ -262,17 +262,8 @@ export function* savePost( options = {} ) {
 		previousRecord.type,
 		previousRecord.id
 	);
-	debugger;
-	if ( error && error.message === 'test' ) {
-		const args = getNotificationArgumentsForSaveFail( {
-			post: previousRecord,
-			edits,
-			error,
-		} );
-		if ( args.length ) {
-			yield dispatch( 'core/notices', 'createErrorNotice', ...args );
-		}
-	} else if ( error ) {
+
+	if ( error && 'offline' === error.type ) {
 		const args = getNotificationArgumentsForOfflineSync( {
 			post: previousRecord,
 			edits,
@@ -283,6 +274,15 @@ export function* savePost( options = {} ) {
 		}
 		if ( ! options.isAutosave ) {
 			yield dispatch( 'core/block-editor', '__unstableMarkLastChangeAsPersistent' );
+		}
+	} else if ( error ) {
+		const args = getNotificationArgumentsForSaveFail( {
+			post: previousRecord,
+			edits,
+			error,
+		} );
+		if ( args.length ) {
+			yield dispatch( 'core/notices', 'createErrorNotice', ...args );
 		}
 	} else {
 		const updatedRecord = yield select( STORE_KEY, 'getCurrentPost' );

--- a/packages/editor/src/store/utils/notice-builder.js
+++ b/packages/editor/src/store/utils/notice-builder.js
@@ -13,6 +13,20 @@ import { SAVE_POST_NOTICE_ID, TRASH_POST_NOTICE_ID } from '../constants';
  */
 import { get, includes } from 'lodash';
 
+export function getNotificationArgumentsForOfflineSync( data ) {
+	const { error } = data;
+	let noticeMessage = '';
+
+	// Check if message string contains HTML. Notice text is currently only
+	// supported as plaintext, and stripping the tags may muddle the meaning.
+	if ( error.message && ! ( /<\/?[^>]*>/.test( error.message ) ) ) {
+		noticeMessage = [ error.message ].join( ' ' );
+	}
+	return [ noticeMessage, {
+		id: SAVE_POST_NOTICE_ID,
+	} ];
+}
+
 /**
  * Builds the arguments for a success notification dispatch.
  *


### PR DESCRIPTION
## Description
<!-- Please describe what you have changed or added -->
This is a PoC PR with the goal of:
- Allow editing a previously loaded post only.
- Display a message about being offline and let the user know that it will be updated later.
- First step: ignore changes done by anyone else and always update the post content when online again.

Potentially later:
- Second step: Use If-Unmodified-Since and create a revision only if the post has been modified meanwhile.

## How has this been tested?
<!-- Please describe in detail how you tested your changes. -->
<!-- Include details of your testing environment, tests ran to see how -->
<!-- your change affects other areas of the code, etc. -->

## Screenshots <!-- if applicable -->

## Types of changes
<!-- What types of changes does your code introduce?  -->
<!-- Bug fix (non-breaking change which fixes an issue) -->
<!-- New feature (non-breaking change which adds functionality) -->
<!-- Breaking change (fix or feature that would cause existing functionality to not work as expected) -->

## Checklist:
- [ ] My code is tested.
- [ ] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/javascript/ -->
- [ ] My code follows the accessibility standards. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/accessibility-coding-standards/ -->
- [ ] My code has proper inline documentation. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/javascript/ -->
- [ ] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
- [ ] I've updated all React Native files affected by any refactorings/renamings in this PR. <!-- React Native mobile Gutenberg guidelines: https://github.com/WordPress/gutenberg/blob/master/docs/contributors/native-mobile.md -->.
